### PR TITLE
triple-quote strings and comment character

### DIFF
--- a/examples/#3.tick
+++ b/examples/#3.tick
@@ -1,0 +1,12 @@
+var query = batch|query(
+  '''
+    select
+      last(messages) as messages,
+      last(messages_ready) as messages,
+      max(messages) as max_messages,
+      last(messages) - first(messages) as new_messages,
+      last(messages_ack) - first(messages_ack) as acked,
+      mean(messages_publish_rate) as publish_rate
+    from
+      "rabbitmq"."default"."rabbitmq_queue"
+  ''')

--- a/grammars/tick.cson
+++ b/grammars/tick.cson
@@ -112,6 +112,17 @@
   'strings':
     'patterns': [
       {
+        'begin': '\'\'\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.tick'
+        'end': '\'\'\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.tick'
+        'name': 'string.quoted.multiline.tick'
+      }
+      {
         'begin': '\''
         'beginCaptures':
           '0':

--- a/settings/language-tick.cson
+++ b/settings/language-tick.cson
@@ -1,0 +1,3 @@
+'.source.tick':
+  'editor':
+    'commentStart': '// '


### PR DESCRIPTION
Hello, 

I've added support for triple-quoted strings, and adjusted the comment character to be '//'. This should fix #2 and #3. 